### PR TITLE
tableId prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ API Structure:
 | additionalProps | object | additional props that are passed to the internal components (see full list of [additionalProps](#additionalProps)) | {} |
 | icons | object | the icons that are in use by the table | { sortAscending, sortDescending, clearSelection, columnVisibility, search, loader } |
 | texts | object | the texts that are in use by the table | { search, totalRows, rows, selected, rowsPerPage, page, of, prev, next, columnVisibility } |
+| tableId | string | table unique identifier | random string |
 
 ### refs
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ export default MyAwesomeTable;
 | pageSize | number | the selected page size | 20 |
 | sort | object | sort config. accepts `colId` for the id of the column that should be sorted, and `isAsc` to define the sort direction. example: `{ colId: 'some-column-id', isAsc: true }`, to unsort simply pass `colId` as `null` | { } |
 | isLoading | boolean | whether to display the loader | false |
+| tableId | string | table unique identifier | random string |
 
 ### Configuration props
 

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
         "dist"
     ],
     "dependencies": {
+        "nanoid": "^3.1.20",
         "react-sortable-hoc": "^1.11.0",
         "react-virtual": "^2.3.0"
     }

--- a/src/components/CellContainer.jsx
+++ b/src/components/CellContainer.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import { getHighlightedText } from '../utils';
 
 const CellContainer = ({
+    tableId,
     rowId,
     data,
     column,
@@ -29,7 +30,7 @@ const CellContainer = ({
 
     const getClassNames = () => {
         let classNames;
-        const all = `rgt-cell rgt-row-${rowIndex} rgt-row-${rowIndex % 2 === 0 ? 'even' : 'odd'}${isSelected ? ' rgt-row-selected' : ''}${isEdit ? ' rgt-row-edit' : ''} ${additionalProps.className || ''}`.trim();
+        const all = `rgt-cell rgt-${tableId} rgt-row-${rowIndex} rgt-row-${rowIndex % 2 === 0 ? 'even' : 'odd'}${isSelected ? ' rgt-row-selected' : ''}${isEdit ? ' rgt-row-edit' : ''} ${additionalProps.className || ''}`.trim();
         const virtualDefault = `${!tableHasSelection ? '' : disableSelection ? ' rgt-row-not-selectable' : ' rgt-row-selectable'}`;
         const checkboxDefault = `${column.pinned && colIndex === 0 ? ' rgt-cell-pinned rgt-cell-pinned-left' : ''}${column.pinned && colIndex === visibleColumns.length - 1 ? ' rgt-cell-pinned rgt-cell-pinned-right' : ''} ${column.className}`.trim();
 
@@ -59,18 +60,18 @@ const CellContainer = ({
 
     const onMouseOver = useCallback(
         event => {
-            document.querySelectorAll(`.rgt-row-${rowIndex}`).forEach(cell => cell.classList.add('rgt-row-hover')); 
+            document.querySelectorAll(`.rgt-row-${rowIndex}.rgt-${tableId}`).forEach(cell => cell.classList.add('rgt-row-hover')); 
             additionalProps.onMouseOver?.(event);
         },
-        [rowIndex, additionalProps.onMouseOver]
+        [tableId, rowIndex, additionalProps.onMouseOver]
     )
     
     const onMouseOut = useCallback(
         event => { 
-            document.querySelectorAll(`.rgt-row-${rowIndex}`).forEach(cell => cell.classList.remove('rgt-row-hover')); 
+            document.querySelectorAll(`.rgt-row-${rowIndex}.rgt-${tableId}`).forEach(cell => cell.classList.remove('rgt-row-hover')); 
             additionalProps.onMouseOut?.(event);
         },
-        [rowIndex, additionalProps.onMouseOut]
+        [tableId, rowIndex, additionalProps.onMouseOut]
     )
 
     if (data && onRowClick) {

--- a/src/components/Row.jsx
+++ b/src/components/Row.jsx
@@ -8,7 +8,7 @@ const Row = ({
     measureRef
 }) => {
     const {
-        config: { isVirtualScroll, rowIdField },
+        config: { isVirtualScroll, tableId, rowIdField },
         rowEditApi: { editRow, getIsRowEditable },
         rowSelectionApi: { getIsRowSelectable, selectedRowsIds },
         columnsApi: { visibleColumns },
@@ -36,7 +36,8 @@ const Row = ({
     let isEdit = !!data && editRow?.[rowIdField] === rowId && !!getIsRowEditable(data);
     
     return visibleColumns.map((visibleColumn, colIndex) =>
-        <CellContainer 
+        <CellContainer
+            tableId={tableId}
             key={`${visibleColumn.id}-${rowId}`}
             rowId={rowId}
             data={rowId && (editRow?.[rowIdField] === rowId) ? editRow : data} 

--- a/src/hooks/useTableManager.jsx
+++ b/src/hooks/useTableManager.jsx
@@ -32,6 +32,7 @@ const useTableManager = (props) => {
 
     tableManager.mode = !props.onRowsRequest ? 'sync' : 'async';
     tableManager.config = {
+        tableId: props.tableId,
         rowIdField: props.rowIdField,
         minColumnResizeWidth: props.minColumnResizeWidth,
         minSearchChars: props.minSearchChars,

--- a/src/hooks/useTableManager.jsx
+++ b/src/hooks/useTableManager.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { nanoid } from 'nanoid';
 import * as components from '../components';
 import { icons, texts } from '../defaults';
 import {
@@ -32,7 +33,7 @@ const useTableManager = (props) => {
 
     tableManager.mode = !props.onRowsRequest ? 'sync' : 'async';
     tableManager.config = {
-        tableId: props.tableId,
+        tableId: props.tableId === '' ? nanoid(10) : props.tableId,
         rowIdField: props.rowIdField,
         minColumnResizeWidth: props.minColumnResizeWidth,
         minSearchChars: props.minSearchChars,

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { SortableContainer } from 'react-sortable-hoc';
-import { nanoid } from 'nanoid';
 import { Row, HeaderCellContainer } from './components/';
 import { useTableManager } from './hooks/';
 import PropTypes from 'prop-types';
@@ -10,13 +9,12 @@ const SortableList = SortableContainer(({ forwardRef, className, style, children
     <div ref={forwardRef} className={className} style={style}>{children}</div>);
  
 const GridTable = props => {
-
-    const tableId = props.tableId === '' ? nanoid(10) : props.tableId;
-    const tableManager = useTableManager({ ...props, tableId });
+    const tableManager = useTableManager({ ...props });
 
     const {
         isLoading,
         config: {
+            tableId,
             isVirtualScroll,
             rowIdField,
             components: { Header, Footer, Loader, NoResults, DragHandle },

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { SortableContainer } from 'react-sortable-hoc';
+import { nanoid } from 'nanoid';
 import { Row, HeaderCellContainer } from './components/';
 import { useTableManager } from './hooks/';
 import PropTypes from 'prop-types';
@@ -10,7 +11,8 @@ const SortableList = SortableContainer(({ forwardRef, className, style, children
  
 const GridTable = props => {
 
-    const tableManager = useTableManager(props);
+    const tableId = props.tableId === '' ? nanoid(10) : props.tableId;
+    const tableManager = useTableManager({ ...props, tableId });
 
     const {
         isLoading,
@@ -32,7 +34,7 @@ const GridTable = props => {
         return rest;
     }, {})
 
-    const classNames = ('rgt-wrapper ' + (props.className || '')).trim();
+    const classNames = (`rgt-wrapper rgt-${tableId} ` + (props.className || '')).trim();
 
     return (
         <div {...rest} ref={rgtRef} className={classNames}>
@@ -88,6 +90,7 @@ const GridTable = props => {
 }
 
 GridTable.defaultProps = {
+    tableId: '',
     columns: [],
     rowIdField: 'id',
     minColumnResizeWidth: 70,
@@ -109,6 +112,7 @@ GridTable.defaultProps = {
 
 GridTable.propTypes = {
     // general
+    tableId: PropTypes.string,
     columns: PropTypes.arrayOf(PropTypes.object).isRequired,
     rows: PropTypes.arrayOf(PropTypes.object),
     selectedRowsIds: PropTypes.array,


### PR DESCRIPTION
This PR adds tableId prop which uses in class names, on the wrapper level and for each cell. It needed to identify which cell was hovered. Because now, if you have more than 1 table on a page on move mouse over, let's say, 1 row, we have all first rows highlighted in all tables. This PR fixes this issue. By default tableId is generated by nanoid package or might be set manually.

And I added it to Readme.md.