### PR TITLE
Directly includes core-js in @babel/preset-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
         "dist"
     ],
     "dependencies": {
+        "core-js": "^3.9.1",
         "react-sortable-hoc": "^1.11.0",
         "react-virtual": "^2.3.0"
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
                 use: {
                     loader: 'babel-loader',
                     options: {
-                        presets: ['@babel/preset-env', '@babel/preset-react'],
+                        presets: [['@babel/preset-env', {"useBuiltIns": "usage", "corejs": 3}], '@babel/preset-react'],
                         plugins: ['@babel/plugin-proposal-object-rest-spread']
                     }
                 },


### PR DESCRIPTION
Directly includes core-js in @babel/preset-env as per recommendations from https://babeljs.io/docs/en/babel-preset-env#usebuiltins

Unbreaks the component for React setups without global core-js. Fixes #64.