### PR TITLE
rowIndex is set incorrectly on the last page.

### DIFF
--- a/src/components/Row.jsx
+++ b/src/components/Row.jsx
@@ -12,7 +12,7 @@ const Row = ({
         rowEditApi: { editRow, getIsRowEditable },
         rowSelectionApi: { getIsRowSelectable, selectedRowsIds },
         columnsApi: { visibleColumns },
-        paginationApi: { pageRows, page },
+        paginationApi: { pageRows, page, pageSize },
         rowVirtualizer: { virtualItems, totalSize },
     } = tableManager;
 
@@ -29,7 +29,7 @@ const Row = ({
         }
     }
 
-    let rowIndex = (index+1) + (pageRows.length * page - pageRows.length);
+    let rowIndex = (index+1) + pageSize * (page - 1);
     let rowId = data?.[rowIdField] || rowIndex;
     let disableSelection = !data || !getIsRowSelectable(data);
     let isSelected = !!data && !!(selectedRowsIds.find(selectedRowId => selectedRowId === rowId));


### PR DESCRIPTION
rowIndex is set incorrectly on the last page, as the last page might have fewer rows than pagesize. For example, if a table has 33 table rows and we are on page 4.
Then pageRows.size would be 3 and rowindex of the first row on page 4 would be 10 but the correct value is 31.