### PR TITLE
fix-useResizeEvents-declare-order

### DIFF
--- a/src/hooks/useResizeEvents.jsx
+++ b/src/hooks/useResizeEvents.jsx
@@ -7,6 +7,31 @@ const useResizeEvents = (
     onResize,
     onResizeEnd
 ) => {
+    const onMouseMove = useCallback(
+        (event) => {
+            onResize({ event, target: resizeHandleRef.current, column });
+        },
+        [column, onResize, resizeHandleRef]
+    );
+
+    const onMouseUp = useCallback(
+        (event) => {
+            onResizeEnd({ event, target: resizeHandleRef.current, column });
+            window.removeEventListener("mousemove", onMouseMove);
+            window.removeEventListener("mouseup", onMouseUp);
+        },
+        [column, onMouseMove, onResizeEnd, resizeHandleRef]
+    );
+
+    const onMouseDown = useCallback(
+        (event) => {
+            onResizeStart({ event, target: resizeHandleRef.current, column });
+            window.addEventListener("mousemove", onMouseMove);
+            window.addEventListener("mouseup", onMouseUp);
+        },
+        [column, onMouseMove, onMouseUp, onResizeStart, resizeHandleRef]
+    );
+
     useEffect(() => {
         const resizeEl = resizeHandleRef.current;
         if (resizeEl) resizeEl.addEventListener("mousedown", onMouseDown);
@@ -27,31 +52,6 @@ const useResizeEvents = (
         onMouseMove,
         onMouseUp,
     ]);
-
-    const onMouseDown = useCallback(
-        (event) => {
-            onResizeStart({ event, target: resizeHandleRef.current, column });
-            window.addEventListener("mousemove", onMouseMove);
-            window.addEventListener("mouseup", onMouseUp);
-        },
-        [column, onMouseMove, onMouseUp, onResizeStart, resizeHandleRef]
-    );
-
-    const onMouseMove = useCallback(
-        (event) => {
-            onResize({ event, target: resizeHandleRef.current, column });
-        },
-        [column, onResize, resizeHandleRef]
-    );
-
-    const onMouseUp = useCallback(
-        (event) => {
-            onResizeEnd({ event, target: resizeHandleRef.current, column });
-            window.removeEventListener("mousemove", onMouseMove);
-            window.removeEventListener("mouseup", onMouseUp);
-        },
-        [column, onMouseMove, onResizeEnd, resizeHandleRef]
-    );
 };
 
 export default useResizeEvents;


### PR DESCRIPTION
Due to the order of variable declarations in `src/hooks/useResizeEvents.jsx`, the project cannot be used by Vite/Esbuild (which is always in strict mode, and cannot handle (for example) `onMouseDown` being used before its declaration.

The problem can be fixed by simply re-ordering the statements.